### PR TITLE
Fix crash caused by unsafe cast

### DIFF
--- a/src/main/java/com/github/lehjr/powersuits/client/event/RenderEventHandler.java
+++ b/src/main/java/com/github/lehjr/powersuits/client/event/RenderEventHandler.java
@@ -99,6 +99,7 @@ public enum RenderEventHandler {
 
     private boolean playerHasFlightOn(PlayerEntity player) {
         return
+
                 player.getItemStackFromSlot(EquipmentSlotType.HEAD).getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
                         .filter(IModularItem.class::isInstance)
                         .map(IModularItem.class::cast)

--- a/src/main/java/com/github/lehjr/powersuits/client/event/RenderEventHandler.java
+++ b/src/main/java/com/github/lehjr/powersuits/client/event/RenderEventHandler.java
@@ -99,20 +99,21 @@ public enum RenderEventHandler {
 
     private boolean playerHasFlightOn(PlayerEntity player) {
         return
-
                 player.getItemStackFromSlot(EquipmentSlotType.HEAD).getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
-                        .map(iModularItem ->
-                                (iModularItem instanceof IModularItem) && ((IModularItem) iModularItem).isModuleOnline(MPSRegistryNames.FLIGHT_CONTROL_MODULE_REGNAME)).orElse(false) ||
+                        .filter(IModularItem.class::isInstance)
+                        .map(IModularItem.class::cast)
+                        .map(iModularItem -> iModularItem.isModuleOnline(MPSRegistryNames.FLIGHT_CONTROL_MODULE_REGNAME)).orElse(false) ||
 
                         player.getItemStackFromSlot(EquipmentSlotType.CHEST).getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
-                                .map(iModularItem ->
-                                        (iModularItem instanceof IModularItem) &&
-                                                ((IModularItem) iModularItem).isModuleOnline(MPSRegistryNames.JETPACK_MODULE_REGNAME) ||
-                                                ((IModularItem) iModularItem).isModuleOnline(MPSRegistryNames.GLIDER_MODULE_REGNAME)).orElse(false) ||
+                                .filter(IModularItem.class::isInstance)
+                                .map(IModularItem.class::cast)
+                                .map(iModularItem -> iModularItem.isModuleOnline(MPSRegistryNames.JETPACK_MODULE_REGNAME) ||
+                                        iModularItem.isModuleOnline(MPSRegistryNames.GLIDER_MODULE_REGNAME)).orElse(false) ||
 
                         player.getItemStackFromSlot(EquipmentSlotType.FEET).getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
-                                .map(iModularItem ->
-                                        (iModularItem instanceof IModularItem) && ((IModularItem) iModularItem).isModuleOnline(MPSRegistryNames.JETBOOTS_MODULE_REGNAME)).orElse(false);
+                                .filter(IModularItem.class::isInstance)
+                                .map(IModularItem.class::cast)
+                                .map(iModularItem -> iModularItem.isModuleOnline(MPSRegistryNames.JETBOOTS_MODULE_REGNAME)).orElse(false);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
This mod caused a crash with one of my mods by making an unsafe cast see Crimix/jetboots#23.
`java.lang.ClassCastException: com.black_dog20.jetboots.common.util.EnchantableItemHandler cannot be cast to com.github.lehjr.numina.util.capabilities.inventory.modularitem.IModularItem`

I think it was caused by line 110-111 because of how the logic statement was evaluated as 
`( (iModularItem instanceof IModularItem) && ((IModularItem) iModularItem).isModuleOnline(MPSRegistryNames.JETPACK_MODULE_REGNAME) ) || ((IModularItem) iModularItem).isModuleOnline(MPSRegistryNames.GLIDER_MODULE_REGNAME)` 
instead of
`(iModularItem instanceof IModularItem) && ( ((IModularItem) iModularItem).isModuleOnline(MPSRegistryNames.JETPACK_MODULE_REGNAME) || ((IModularItem) iModularItem).isModuleOnline(MPSRegistryNames.GLIDER_MODULE_REGNAME) )`

This PR fixes the issue by using the filter and map methods of the LazyOptional to cast the Item handler to IModularItem thus making the code more robust

Fixes Crimix/jetboots#23