### PR TITLE
[1.12.2] Fix ConcurrentModificationExceptions in ModuleManager

### DIFF
--- a/src/main/java/net/machinemuse/powersuits/common/base/ModuleManager.java
+++ b/src/main/java/net/machinemuse/powersuits/common/base/ModuleManager.java
@@ -13,7 +13,7 @@ import net.minecraft.util.NonNullList;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 
 public enum ModuleManager implements IModuleManager {
@@ -21,7 +21,7 @@ public enum ModuleManager implements IModuleManager {
 
     protected static final Map<String, NonNullList<ItemStack>> installCosts = new HashMap<>();
     protected static Map<String, NonNullList<ItemStack>> customInstallCosts = new HashMap<>();
-    protected static final Map<String, IPowerModule> moduleMap = new LinkedHashMap<>();
+    protected static final Map<String, IPowerModule> moduleMap = new ConcurrentHashMap<>();
 
     @Override
     public void addModule(IPowerModule module) {


### PR DESCRIPTION
In modpacks, iterating over modules in the `moduleMap` causes CMEs because `getAllModules()` is called by other mods, using The 1.12.2 Pack as an example with JEI: https://github.com/xJon/The-1.12.2-Pack/issues/1000

Implementing a concurrent hash map for this purpose should solve this issue.